### PR TITLE
Update 8_vulnerability_analysis.md

### DIFF
--- a/_labs/introducing_attacks/8_vulnerability_analysis.md
+++ b/_labs/introducing_attacks/8_vulnerability_analysis.md
@@ -235,15 +235,21 @@ nikto -host ==edit:Target-IP-Address==
 
 > Flag: Go find yourself some flags\! There are various vulnerabilities, similar to previous weeks. There is also a new privilege escalation vulnerability this week – so something new for you to try to identify and exploit (another sudo vulnerability). 
 
-> Hint: You cannot exploit the same sudo vulnerability as in the previous lab, because this time you do not know the password of a user for whom you gained the shell access (this is because you have gained the shell access via a vulnerability, not by logging in to the system; this, you are even more limited in what you can do).  
-
 > Hint: Some vulnerable services could be already patched. Thus, consider attacking all available services. 
 
-> Hint: To get all flags you might need to escalate privileges to root. Notice sudo version - this will help to identify an exploitable vulnerability. Also keep in mind the limitation related to the fact that you do not know the user password. 
+> Hint: To get all flags you might need to escalate privileges to root. There are numerous sudo-related vulnerabilities that can be used to escalate privileges to root after gaining initial access to a system. Notice sudo version - this will help to identify an exploitable vulnerability. Also keep in mind the limitation related to the fact that you do not know the user password (this is because you have gained the shell access via a vulnerability, not by logging in to the system; thus, you are even more limited in what you can do - you cannot exploit the same sudo vulnerability as in the previous lab). Instead, you can search Metasploit for the *sudo\_baron\_samedit* exploit. The exploitation complexity is moderate and may require upgrading your current shell to a Meterpreter session. Find how to do it on your own (or read this if you are feeling lazy 😉) [https://infosecwriteups.com/metasploit-upgrade-normal-shell-to-meterpreter-shell-2f09be895646](https://infosecwriteups.com/metasploit-upgrade-normal-shell-to-meterpreter-shell-2f09be895646) . 
 
 ![][metasploit_sudo_baron_samedit_exploit_command]
 
-> Hint: After a few failed attempts to escalate privileges, googling results might suggest that the *sudo\_baron\_samedit* vulnerability needs to be exploited from the Meterpreter shell. Thus, you might need to upgrade your shell to Meterpreter prior to exploiting the sudo vulnerability. Find how to do it on your own (or read this if you are feeling lazy 😉) [https://infosecwriteups.com/metasploit-upgrade-normal-shell-to-meterpreter-shell-2f09be895646](https://infosecwriteups.com/metasploit-upgrade-normal-shell-to-meterpreter-shell-2f09be895646) .
+> Hint: Before attempting exploitation of *sudo\_baron\_samedit* verify whether the target system is actually vulnerable. Review the exploit details using the info command in Metasploit, paying close attention to the affected versions of Linux, sudo, and the libc library. Then, check these versions on your target VM to determine if the exploit is applicable. If it does not seems to be vulnerable, there is still an alternative method on this Debian system to obtain root access and retrieve the final flag. But this is an advanced task. Do not be discouraged if you are unable to complete it.
+
+> Hint: Inspect the */etc/default/* directory. You can find there an file - the initscript, which is related to a vulnerable network service you have already experienced with. This script is executed at system boot by the root user. Although the file is owned by root, it appears to have misconfigured permissions that allow other users to read and modify it. You can append a command to this file, for example (revise the very first lab “*Intro to Linux Security*”):
+
+```bash
+echo "==edit:bash-command-to-create-bind-or-reverse-shell==" >> /etc/default/==edit:name-of-the-network-service==
+```
+
+> Hint: By doing so, you can insert a command that establishes a bind or reverse shell each time the system reboots. You may use netcat, which can act as both a listener and a client on Kali and Debian (revise the lab “*Vulnerabilties. Exploits and Remote Access Payloads*” or read this [https://www.invicti.com/learn/reverse-shell](https://www.invicti.com/learn/reverse-shell) and this [https://infosecwriteups.com/create-bind-and-reverse-shells-using-netcat-c53b23df8059](https://infosecwriteups.com/create-bind-and-reverse-shells-using-netcat-c53b23df8059)). 
 
 ## Conclusion
 


### PR DESCRIPTION
sudo_baron is deprecated (libc version > 3.31). Gaining root is still possible via altering the startup script /etc/default/distcc by adding a bash command creating a bind or reverse shell (it is executed with root privileges). nc can be used on Kali to connect after the Linux is restarted.